### PR TITLE
Some README clarifications about running as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ __syftr__ is an agent optimizer that helps you find the best agentic workflows f
 [Paper](https://arxiv.org) | [Blogpost](https://www.datarobot.com)
 
 ### Installation
-=======
 Please clone the __syftr__ repo and run:
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
Currently, configuring `syfrt` to be run as a library is not documented, so we should communicate our expectations from the current runtime configuration.
Let me know if you want to reword this.
Resolves #21 