### PR TITLE
Fix knee point

### DIFF
--- a/studies/example-dr-docs.yaml
+++ b/studies/example-dr-docs.yaml
@@ -3,10 +3,9 @@ dataset:
 name: example-dr-docs
 optimization:
   cpus_per_trial: 1
-  embedding_device: cpu
-  max_concurrent_trials: 4
+  max_concurrent_trials: 10
   num_eval_batch: 5
-  num_eval_samples: 10
+  num_eval_samples: 5
   num_trials: 10
 recreate_study: true
 reuse_study: false

--- a/syftr/api.py
+++ b/syftr/api.py
@@ -152,6 +152,10 @@ class Study:
     def knee_point(self) -> T.Dict[str, T.Any]:
         """Return the knee point of the Pareto front of a completed study."""
         df_pareto = self.pareto_df
+        if len(df_pareto) < 3:
+            raise SyftrUserAPIError(
+                "Not enough points in the Pareto front to find a knee point."
+            )
         knee = KneeLocator(
             df_pareto["values_1"],
             df_pareto["values_0"],
@@ -159,6 +163,8 @@ class Study:
             direction="increasing",
         )
         knee_point = knee.knee
+        if knee_point is None:
+            raise SyftrUserAPIError("Unable to find knee point in the Pareto front.")
         df_knee = df_pareto[df_pareto["values_1"] == knee_point]
         flow_params = json.loads(df_knee["user_attrs_flow"].values[0])
         obj1_name = self.study_config.optimization.objective_1_name

--- a/syftr/studies.py
+++ b/syftr/studies.py
@@ -1310,7 +1310,7 @@ class OptimizationConfig(BaseModel):
         default=0.0, description="Number of GPUs allocated per trial."
     )
     embedding_device: EmbeddingDeviceType = Field(
-        default="onnx-cpu",
+        default=None,
         description="Device to use for embeddings (e.g., 'cpu', 'cuda', 'onnx-cpu'). Use `None` to auto-detect.",
     )
     use_hf_embedding_models: bool = Field(


### PR DESCRIPTION
Small PR to throw an exception when we are unable to calculate a knee point (due to the Pareto having too few (<3) points). Also defaults to embedding_device=None. Finally, makes some changes to our example config in the interest of getting it to run quicker.