### PR TITLE
Make ray submit agnostic of studies/ directory

### DIFF
--- a/syftr/ray/runtime_env.py
+++ b/syftr/ray/runtime_env.py
@@ -7,6 +7,7 @@ for detailed documentation of this file's parameters.
 
 import shutil
 import tomllib
+from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
@@ -44,7 +45,7 @@ def _build_excludes() -> List[str]:
     return sorted(list(excludes))
 
 
-def _prepare_working_dir() -> str:
+def _prepare_working_dir(study_config_path: Path) -> str:
     root = cfg.paths.root_dir
     dest = root / "ray_working_dir"
 
@@ -56,9 +57,7 @@ def _prepare_working_dir() -> str:
     with open(dest / "config.yaml", "w") as cfg_file:
         yaml.dump(cfg_data, cfg_file)
 
-    # TODO: load current study data and dump to a yaml instead
-    # of requiring studies directory
-    shutil.copytree(root / "studies", dest / "studies")
+    shutil.copy(study_config_path, dest)
 
     return dest.as_posix()
 
@@ -69,11 +68,11 @@ def _prepare_modules():
     return [syftr]
 
 
-def get_runtime_env(delete_confirmed: bool = False) -> Dict[str, Any]:
+def get_runtime_env(study_config_path: Path, delete_confirmed: bool = False) -> Dict[str, Any]:
     return {
         "env_vars": _build_env(delete_confirmed),
         "pip": _build_pip(),
         "py_modules": _prepare_modules(),
-        "working_dir": _prepare_working_dir(),
+        "working_dir": _prepare_working_dir(study_config_path),
         "excludes": _build_excludes(),
     }

--- a/syftr/ray/submit.py
+++ b/syftr/ray/submit.py
@@ -58,12 +58,14 @@ def start_study(
 ) -> str:
     metadata = _get_metadata(study_config)
     submission_id = _get_submission_id(metadata)
-    runtime_env = get_runtime_env(delete_confirmed)
+    runtime_env = get_runtime_env(study_config_file, delete_confirmed)
 
     if not agentic:
-        entrypoint = f"python -m syftr.tuner.qa_tuner --study-config {study_config_file.as_posix()}"
+        # runtime_env contains study config file in the root of the working directory
+        # regardless of where the study config file came from
+        entrypoint = f"python -m syftr.tuner.qa_tuner --study-config {study_config_file.name}"
     else:
-        entrypoint = f"python -m syftr.tuner.agent_tuner --study-config {study_config_file.as_posix()}"
+        entrypoint = f"python -m syftr.tuner.agent_tuner --study-config {study_config_file.name}"
 
     if not cfg.ray.local:
         logger.info(


### PR DESCRIPTION
This should allow ray.submit to work from anywhere, as in usage of syftr as a library, without a fixed `studies` directory.

Simply copies the study config file that was passed in and puts it in the root of the working directory.

Resolves https://github.com/datarobot/syftr/issues/47