### PR TITLE
Don't load empty HF_TOKEN into env

### DIFF
--- a/syftr/llm.py
+++ b/syftr/llm.py
@@ -34,7 +34,7 @@ def _scale(
     return int(context_window_length * factor)
 
 
-if hf_token := cfg.hf_embeddings.api_key.get_secret_value() != "NOT SET":
+if (hf_token := cfg.hf_embeddings.api_key.get_secret_value()) != "NOT SET":
     os.environ["HF_TOKEN"] = hf_token
 
 


### PR DESCRIPTION
Resolves https://github.com/datarobot/syftr/issues/17

HF_TOKEN being set to 'NOT SET' causes the Huggingface Hub client to attempt to authenticate regardless of whether it's necessary to do so, causing it to block ordinary OSS model downloads.