### PR TITLE
Don't document HF API key requirement as needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ __syftr__'s examples require the following credentials:
 * Azure OpenAI API key
 * Azure OpenAI endpoint URL (`api_url`)
 * PostgreSQL server dsn
-* Huggingface API key
 
 To enter these credentials, copy [config.yaml.sample](config.yaml.sample) to `config.yaml` and edit the required portions.
 

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -24,10 +24,6 @@ gcp_vertex:
       ...
     }
 
-# HuggingFace Embeddings (required for most experiments)
-hf_embeddings:
-  api_key: "asdf1234"
-
 # Use any relational DB provider supported by Optuna storage (required)
 postgres:
   dsn: "postgresql://user:pass@postgresserver:5432/syftr"


### PR DESCRIPTION
Since the [bug](https://github.com/datarobot/syftr/issues/17) is [fixed](https://github.com/datarobot/syftr/pull/52), the API key is only needed for loading models behind a ToS agreement or using HF Inference API, which is not enabled by default