### PR TITLE
More changes to config.yaml.sample

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -14,21 +14,21 @@ gcp_vertex:
   project_id: "<your-project-id>"
   region: "europe-west1"
   # Put your GCP credentials file in runtime-secrets/gcp_vertex__credentials
-  # Or place it here:
-  credentials: >
-    {
-      "type": "service_account",
-      "project_id": "<your-project-id>",
-      "private_key_id": "<your-private-key-id>",
-      "private_key": "<your-private-key>",
-      "client_email": "<your-client-email>",
-      "client_id": "<your-client-id>",
-      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-      "token_uri": "https://oauth2.googleapis.com/token",
-      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-      "client_x509_cert_url": "<your-cert-url>",
-      "universe_domain": "googleapis.com"
-    }
+  # Or uncomment the following:
+  # credentials: >
+  #   {
+  #     "type": "service_account",
+  #     "project_id": "<your-project-id>",
+  #     "private_key_id": "<your-private-key-id>",
+  #     "private_key": "<your-private-key>",
+  #     "client_email": "<your-client-email>",
+  #     "client_id": "<your-client-id>",
+  #     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  #     "token_uri": "https://oauth2.googleapis.com/token",
+  #     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  #     "client_x509_cert_url": "<your-cert-url>",
+  #     "universe_domain": "googleapis.com"
+  #   }
 
 # Required for mistral-large LLM
 azure_inference_mistral:
@@ -63,11 +63,11 @@ togetherai:
 hf_embeddings:
   api_key: "<your-api-key>"
 
-# Use any relational DB provider supported by Optuna storage (required).
+# Use any relational DB provider supported by Optuna storage (recommended).
 # If no dsn is provided, will use SQLite by default which allows running smaller
 # examples locally.
-database:
-  dsn: "postgresql://user:pass@postgresserver:5432/syftr"
+# database:
+#   dsn: "postgresql://user:pass@postgresserver:5432/syftr"
   # Optionally tune conection args.
   # Sessions must last a long time, so should be resilient to transient network interruptions
   #


### PR DESCRIPTION
Small changes to config.yaml.sample to make it smoother for a new user.

The default GCP vertex creds result in an error upon loading llm.py, so we comment them out.

The default database dsn results it a non-working database connection, so we comment it out to default to sqlite.