### PR TITLE
Install uv before building the package when publishing on PyPI

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -20,8 +20,11 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ">=0.4.24"
+          enable-cache: true
+          cache-local-path: /home/runner/work/_temp/setup-uv-cache
 
       - name: Build release distributions
         run: |


### PR DESCRIPTION
It seems like `uv` is not a part of the `setup-python`