### PR TITLE
Make LLMs configurable from config.yaml

### DIFF
--- a/syftr/configuration.py
+++ b/syftr/configuration.py
@@ -64,11 +64,15 @@ import socket
 import tempfile
 import typing as T
 from pathlib import Path
+from typing import Any, Dict, Literal, Optional, Union
 
+from google.cloud.aiplatform_v1beta1.types import content
+from llama_index.core.base.llms.types import LLMMetadata
 from optuna.storages import RDBStorage
 from pydantic import (
     AnyUrl,
     BaseModel,
+    ConfigDict,
     Field,
     HttpUrl,
     SecretStr,
@@ -326,6 +330,178 @@ class HFEmbeddings(BaseModel, APIKeySerializationMixin):
     }
 
 
+class AzureOAI(BaseModel, APIKeySerializationMixin):
+    # Use cfg.azure_oai.api_key.get_secret_value() to get value
+    api_key: SecretStr = SecretStr("NOT SET")
+    default_deployment: str = "gpt-4o-mini"
+    api_url: HttpUrl = HttpUrl("http://NOT.SET")
+
+    api_version: str = "2024-07-18"
+    api_type: str = "azure"
+
+
+class GCPVertex(BaseModel, APIKeySerializationMixin):
+    # Use cfg.gcp_vertex.credentials.get_secret_value() to get value
+    # Note credentials are a string, typically will need to do a json.loads
+    project_id: str = "NOT SET"
+    region: str = "NOT SET"
+    credentials: SecretStr = SecretStr("NOT SET")
+
+
+class LLMCostTokens(BaseModel):
+    type: Literal["tokens"] = "tokens"
+    input: float = Field(description="Cost per million input tokens")
+    output: float = Field(description="Cost per million output tokens")
+
+
+class LLMCostCharacters(BaseModel):
+    type: Literal["characters"] = "characters"
+    input: float = Field(description="Cost per million input characters")
+    output: float = Field(description="Cost per million output characters")
+
+
+class LLMCostHourly(BaseModel):
+    type: Literal["hourly"] = "hourly"
+    rate: float = Field(
+        description="Average inference cost per hour "
+        "(eg. machine hourly rate divided by average number of concurrent requests)"
+    )
+
+
+class LLMConfig(BaseModel):
+    cost: Annotated[
+        Union[LLMCostTokens, LLMCostCharacters, LLMCostHourly],
+        Field(discriminator="type"),
+    ] = Field(description="LLM inference costs by token, character, or hourly rate.")
+
+    metadata: LLMMetadata = Field(
+        description="LLM Metadata such as context window and capabilities"
+    )
+
+    temperature: float = 0.0
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# Specific LLM Instance Configurations
+class AzureOpenAILLM(LLMConfig):
+    provider: Literal["azure_openai"] = "azure_openai"
+    deployment_name: Optional[str] = None
+    api_version: Optional[str] = None
+    max_retries: int = 0
+    additional_kwargs: Optional[Dict[str, Any]] = None
+
+
+GCP_SAFETY_SETTINGS = {
+    content.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: content.SafetySetting.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+    content.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: content.SafetySetting.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+    content.HarmCategory.HARM_CATEGORY_HARASSMENT: content.SafetySetting.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+    content.HarmCategory.HARM_CATEGORY_HATE_SPEECH: content.SafetySetting.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+}
+
+
+class VertexAILLM(LLMConfig):
+    provider: Literal["vertex_ai"] = "vertex_ai"
+    model: Optional[str] = None
+    safety_settings: dict = GCP_SAFETY_SETTINGS
+    max_retries: int = 0
+    additional_kwargs: Optional[Dict[str, Any]] = None
+
+
+class AnthropicVertexLLM(LLMConfig):
+    provider: Literal["anthropic_vertex"] = Field(
+        "anthropic_vertex", description="Provider identifier."
+    )
+    model: str = Field(
+        description="Name of the Anthropic model on Vertex AI (e.g., claude-3-5-sonnet-v2@20241022)."
+    )
+    project_id: Optional[str] = Field(
+        default=None,
+        description="GCP Project ID. If None, uses global cfg.gcp_vertex.project_id.",
+    )
+    region: Optional[str] = Field(
+        default=None,
+        description="GCP Region. If None, uses global cfg.gcp_vertex.region.",
+    )
+    max_retries: int = Field(
+        default=0, description="Maximum number of retries for API calls."
+    )
+    additional_kwargs: Optional[Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Additional keyword arguments for the Anthropic model.",
+    )
+
+
+class AzureAICompletionsLLM(LLMConfig):
+    provider: Literal["azure_ai"] = Field(
+        "azure_ai", description="Provider identifier."
+    )
+    model_name: str = Field(
+        description="Model name as recognized by Azure AI Completions (e.g., Llama-3.3-70B-Instruct)."
+    )
+    endpoint: HttpUrl = Field(description="API URL for this model")
+    api_key: SecretStr = Field(description="API key for this model")
+    max_retries: int = Field(
+        default=0, description="Maximum number of retries for API calls."
+    )
+    additional_kwargs: Optional[Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Additional keyword arguments for the Azure AI Completions model.",
+    )
+
+
+class CerebrasLLM(LLMConfig):
+    provider: Literal["cerebras"] = Field(
+        "cerebras", description="Provider identifier."
+    )
+    model: str = Field(description="Name of the Cerebras model (e.g., llama3.1-8b).")
+    # API key and URL are typically derived from cfg.cerebras.
+    max_retries: int = Field(
+        default=0, description="Maximum number of retries for API calls."
+    )
+    additional_kwargs: Optional[Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Additional keyword arguments for the Cerebras model.",
+    )
+
+
+class OpenAILikeLLM(LLMConfig):
+    provider: Literal["openai_like"] = Field(
+        "openai_like", description="Provider identifier for OpenAI-compatible APIs."
+    )
+    model: str = Field(
+        description="Name of the OpenAI-like model (e.g., meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo)."
+    )
+    api_base: HttpUrl = Field(
+        description="API base URL for the OpenAI-like model."
+    )
+    api_key: SecretStr = Field(description="API key for this endpoint")
+    timeout: int = Field(
+        default=120, description="Timeout in seconds for API requests."
+    )
+    max_retries: int = Field(
+        default=0, description="Maximum number of retries for API calls."
+    )
+    additional_kwargs: Optional[Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Additional keyword arguments for the OpenAI-like model.",
+    )
+
+
+# Update LLMConfigUnion by adding the new classes
+LLMConfigUnion = Annotated[
+    Union[
+        AzureOpenAILLM,
+        VertexAILLM,
+        AnthropicVertexLLM,
+        AzureAICompletionsLLM,
+        CerebrasLLM,
+        OpenAILikeLLM,
+    ],
+    Field(discriminator="provider"),
+]
+
+
 class AzureInferenceLlama33(BaseModel, APIKeySerializationMixin):
     # Use cfg.azure_inference_llama.api_key.get_secret_value() to get value
     api_key: SecretStr = SecretStr("NOT SET")
@@ -372,24 +548,6 @@ class TogetherAI(BaseModel, APIKeySerializationMixin):
 class DataRobot(BaseModel, APIKeySerializationMixin):
     api_key: SecretStr = SecretStr("NOT SET")
     endpoint: HttpUrl = HttpUrl("http://NOT.SET")
-
-
-class AzureOAI(BaseModel, APIKeySerializationMixin):
-    # Use cfg.azure_oai.api_key.get_secret_value() to get value
-    api_key: SecretStr = SecretStr("NOT SET")
-    default_deployment: str = "gpt-4o-mini"
-    api_url: HttpUrl = HttpUrl("http://NOT.SET")
-
-    api_version: str = "2024-07-18"
-    api_type: str = "azure"
-
-
-class GCPVertex(BaseModel, APIKeySerializationMixin):
-    # Use cfg.gcp_vertex.credentials.get_secret_value() to get value
-    # Note credentials are a string, typically will need to do a json.loads
-    project_id: str = "NOT SET"
-    region: str = "NOT SET"
-    credentials: SecretStr = SecretStr("NOT SET")
 
 
 class LocalOpenAILikeModel(BaseModel, APIKeySerializationMixin):
@@ -518,6 +676,9 @@ class Settings(BaseSettings):
     cerebras: Cerebras = Cerebras()
     togetherai: TogetherAI = TogetherAI()
     local_models: LocalOpenAILikeModels = LocalOpenAILikeModels()
+    generative_models: Dict[str, LLMConfigUnion] = Field(
+        default_factory=dict, description="User-provided LLM definitions"
+    )
     logging: Logging = Logging()
     optuna: Optuna = Optuna()
     paths: Paths = Paths()

--- a/syftr/configuration.py
+++ b/syftr/configuration.py
@@ -472,9 +472,7 @@ class OpenAILikeLLM(LLMConfig):
     model: str = Field(
         description="Name of the OpenAI-like model (e.g., meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo)."
     )
-    api_base: HttpUrl = Field(
-        description="API base URL for the OpenAI-like model."
-    )
+    api_base: HttpUrl = Field(description="API base URL for the OpenAI-like model.")
     api_key: SecretStr = Field(description="API key for this endpoint")
     timeout: int = Field(
         default=120, description="Timeout in seconds for API requests."

--- a/syftr/instrumentation/tokens.py
+++ b/syftr/instrumentation/tokens.py
@@ -37,6 +37,7 @@ from opentelemetry.trace import NoOpTracer
 from pydantic import BaseModel, PrivateAttr
 from vertexai.preview.tokenization import get_tokenizer_for_model
 
+from syftr.configuration import cfg
 from syftr.logger import logger
 
 # Unit: $ / token
@@ -100,6 +101,67 @@ MODEL_PRICING_INFO: Dict[str, Dict[str, Dict[str, float]]] = {
         "datarobot/DeepSeek-Llama": {"cost_per_second": 12.06654 / 3600},
     },
 }
+
+if cfg.generative_models:
+    logger.debug(
+        f"Updating MODEL_PRICING_INFO from cfg.generative_models: {list(cfg.generative_models.keys())}"
+    )
+    for config_key, llm_config_item in cfg.generative_models.items():
+        # model_key should match the identifier used by TokenTrackingSpan (usually llm.metadata.model_name)
+        model_key = llm_config_item.metadata.model_name
+
+        if not model_key:
+            logger.warning(
+                f"Model with configuration key '{config_key}' is missing 'metadata.model_name'. "
+                "Skipping its cost info update for MODEL_PRICING_INFO."
+            )
+            continue
+
+        cost_config = llm_config_item.cost
+        cost_type = getattr(cost_config, "type", "unknown")
+
+        if cost_type == "tokens":
+            # Ensure the sub-dictionary for 'tokens' exists
+            MODEL_PRICING_INFO["tokens"].setdefault(model_key, {})
+            # cost_config.input/output are "Cost per million tokens"
+            # MODEL_PRICING_INFO stores "Cost per token"
+            MODEL_PRICING_INFO["tokens"][model_key]["input"] = (
+                cost_config.input / 1_000_000.0
+            )
+            MODEL_PRICING_INFO["tokens"][model_key]["output"] = (
+                cost_config.output / 1_000_000.0
+            )
+            logger.debug(
+                f"Updated token pricing for '{model_key}' from cfg ('{config_key}')."
+            )
+        elif cost_type == "characters":
+            MODEL_PRICING_INFO["characters"].setdefault(model_key, {})
+            # cost_config.input/output are "Cost per million characters"
+            # MODEL_PRICING_INFO stores "Cost per character"
+            MODEL_PRICING_INFO["characters"][model_key]["input"] = (
+                cost_config.input / 1_000_000.0
+            )
+            MODEL_PRICING_INFO["characters"][model_key]["output"] = (
+                cost_config.output / 1_000_000.0
+            )
+            logger.debug(
+                f"Updated character pricing for '{model_key}' from cfg ('{config_key}')."
+            )
+        elif cost_type == "hourly":
+            MODEL_PRICING_INFO["seconds"].setdefault(model_key, {})
+            # cost_config.rate is "Average inference cost per hour"
+            # MODEL_PRICING_INFO stores "Cost per second"
+            MODEL_PRICING_INFO["seconds"][model_key]["cost_per_second"] = (
+                cost_config.rate / 3600.0
+            )
+            logger.debug(
+                f"Updated hourly (per second) pricing for '{model_key}' from cfg ('{config_key}')."
+            )
+        else:
+            logger.warning(
+                f"Unknown or unsupported cost type '{cost_type}' for model '{model_key}' "
+                f"(from cfg key '{config_key}'). Pricing not updated."
+            )
 
 
 class LLMCallData(BaseModel):

--- a/tests/functional/flows/test_llm_token_counter.py
+++ b/tests/functional/flows/test_llm_token_counter.py
@@ -1,7 +1,22 @@
+from syftr.flows import Flow
+
+
 def test_token_counts_basic_generator(basic_flow_all_llms):
     response, duration, call_data = basic_flow_all_llms.generate(
         "What is the capital of France?"
     )
+    assert "paris" in str(response.text).lower()
+    assert duration
+    assert len(call_data) >= 1, call_data
+    assert sum(call.cost for call in call_data) > 0, call_data
+    assert sum(call.input_tokens for call in call_data) > 0, call_data
+    assert sum(call.output_tokens for call in call_data) > 0, call_data
+
+
+def test_token_counts_configurable_models(configured_models):
+    name, llm = configured_models
+    flow = Flow(response_synthesizer_llm=llm)
+    response, duration, call_data = flow.generate("What is the capital of France?")
     assert "paris" in str(response.text).lower()
     assert duration
     assert len(call_data) >= 1, call_data

--- a/tests/functional/test_configurable_models.py
+++ b/tests/functional/test_configurable_models.py
@@ -1,0 +1,20 @@
+# import pytest
+
+from syftr.flows import Flow
+
+# from syftr.llm import load_configured_llms
+
+
+def test_loaded_models(configured_models):
+    name, llm = configured_models
+    llm.complete("hello world")
+
+
+def test_loaded_models_in_flow(configured_models):
+    name, llm = configured_models
+    flow = Flow(response_synthesizer_llm=llm)
+    response, duration, data = flow.generate("hello world")
+    assert response.text
+    assert duration
+    assert data[0].input_tokens
+    assert data[0].output_tokens


### PR DESCRIPTION
Dynamically load LLMs from configs.

This method should eventually replace our existing hardcoded LLMs, but for now this is just adding the capability as an optional addition so that migration to the new configs isn't too difficult.

This has the following benefits
* Easier to add new models. Just create a deployment in your cloud provider and add it to your configuration.
* Adapt to different user environments easily - each user configures for the providers and models they have.

## TODO for this PR
- [ ] Add README.md explanation for using this method
- [ ] Add to config.yaml.sample