### PR TITLE
Make Ray submit workable outside of Git repo

### DIFF
--- a/syftr/ray/submit.py
+++ b/syftr/ray/submit.py
@@ -1,7 +1,6 @@
 import argparse
 import asyncio
 import getpass
-import secrets
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict

--- a/syftr/ray/submit.py
+++ b/syftr/ray/submit.py
@@ -32,17 +32,17 @@ def _get_metadata(study_config: StudyConfig) -> Dict[str, Any]:
         sha = repo.head.commit.hexsha
         short_sha = repo.git.rev_parse(sha, short=True)
     except git.exc.InvalidGitRepositoryError:
-        # We are not in a git repo, syftr used as a library, so generating a random sha.
-        short_sha = secrets.token_hex(nbytes=8)
-        sha = "library_" + short_sha
-    return {
+        # We are not in a git repo, syftr is used as a library,
+        short_sha = None
+    metadata = {
         "study_name": study_config.name,
-        "git_sha": sha,
-        "git_short_sha": short_sha,
         "submitted_by": getpass.getuser(),
         "study_config": study_config.model_dump_json(),
         "config": cfg.model_dump_json(),
     }
+    if short_sha:
+        metadata["git_short_sha"] = short_sha
+    return metadata
 
 
 def _get_submission_id(metadata: Dict[str, Any]):
@@ -50,9 +50,12 @@ def _get_submission_id(metadata: Dict[str, Any]):
     current_time_utc = datetime.now(utc)
     t = current_time_utc.strftime("%Y-%m-%d-%H:%M:%S")
     s = metadata["study_name"]
-    g = metadata["git_short_sha"]
     u = metadata["submitted_by"]
-    return f"{t}--{u}--{s}--{g}"
+    submission_id = f"{t}--{u}--{s}"
+    short_sha = metadata.get("git_short_sha")
+    if short_sha:
+        submission_id += f"--{short_sha}"
+    return submission_id
 
 
 def start_study(

--- a/syftr/ray/submit.py
+++ b/syftr/ray/submit.py
@@ -34,7 +34,7 @@ def _get_metadata(study_config: StudyConfig) -> Dict[str, Any]:
     except git.exc.InvalidGitRepositoryError:
         # We are not in a git repo, syftr used as a library, so generating a random sha.
         short_sha = secrets.token_hex(nbytes=8)
-        sha = "library"
+        sha = "library_" + short_sha
     return {
         "study_name": study_config.name,
         "git_sha": sha,

--- a/syftr/ray/submit.py
+++ b/syftr/ray/submit.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import getpass
+import secrets
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
@@ -26,9 +27,14 @@ def get_client() -> JobSubmissionClient:
 
 
 def _get_metadata(study_config: StudyConfig) -> Dict[str, Any]:
-    repo = git.Repo(cfg.paths.root_dir)
-    sha = repo.head.commit.hexsha
-    short_sha = repo.git.rev_parse(sha, short=True)
+    try:
+        repo = git.Repo(cfg.paths.root_dir)
+        sha = repo.head.commit.hexsha
+        short_sha = repo.git.rev_parse(sha, short=True)
+    except git.exc.InvalidGitRepositoryError:
+        # We are not in git repo, syftr used as a library, so generating a random sha.
+        short_sha = secrets.token_hex(nbytes=8)
+        sha = "library"
     return {
         "study_name": study_config.name,
         "git_sha": sha,

--- a/syftr/ray/submit.py
+++ b/syftr/ray/submit.py
@@ -32,7 +32,7 @@ def _get_metadata(study_config: StudyConfig) -> Dict[str, Any]:
         sha = repo.head.commit.hexsha
         short_sha = repo.git.rev_parse(sha, short=True)
     except git.exc.InvalidGitRepositoryError:
-        # We are not in git repo, syftr used as a library, so generating a random sha.
+        # We are not in a git repo, syftr used as a library, so generating a random sha.
         short_sha = secrets.token_hex(nbytes=8)
         sha = "library"
     return {


### PR DESCRIPTION
syftr generates a Ray job name from Git repo state.  If we want to make it usable as a library, we should support submitting jobs outside of a Git repo and that's what this PR is introducing.