### PR TITLE
Get pip package deps when pyproject.toml is not present

### DIFF
--- a/syftr/ray/runtime_env.py
+++ b/syftr/ray/runtime_env.py
@@ -25,7 +25,8 @@ def _build_pip() -> List[str]:
     except FileNotFoundError:
         # We are not in a git repo, syftr is used as a library.
         from importlib.metadata import version
-        curr_syftr_ver = version('syftr')
+
+        curr_syftr_ver = version("syftr")
         return [f"syftr=={curr_syftr_ver}"]
 
 


### PR DESCRIPTION
Another workaround required to make syftr workable as a library: currently it assumes `pyproject.toml` is present in order to get package dependencies for Ray environment. Use dependencies from `pip` when file is not available.