### PR TITLE
Provide PyPI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ or to use syftr as a library, install directly from PyPi:
 pip install syftr
 ```
 NOTE: __syftr__ works as a library, but still needs easy access to `config.yaml` and study files you intend to run. This file should be present in `~/.syftr/config.yaml`, or your current working directory.
-or current working directory.
 
 ### Required Credentials
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ source .venv/bin/activate
 uv sync --extra dev
 uv pip install -e .
 ```
-or
+or to use syftr as a library, install directly from PyPi:
 ```bash
 pip install syftr
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ source .venv/bin/activate
 uv sync --extra dev
 uv pip install -e .
 ```
+or
+```bash
+pip install syftr
+```
+NOTE: __syftr__ works as a library, but still needs easy access to `config.yaml` and study files you intend to run. This file should be present in `/etc/syftr/config.yaml`, `~/.syftr/config.yaml`
+or current working directory.
 
 ### Required Credentials
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ You can download sample config file to your `~/.syftr` directory with this comma
 curl -L https://raw.githubusercontent.com/datarobot/syftr/main/config.yaml.sample \
      -o ~/.syftr/config.yaml
 ```
+You also need studies to run __syftr__. You can write your own or download our example study with this command to current working directory
+```bash
+curl -L https://raw.githubusercontent.com/datarobot/syftr/main/studies/example-dr-docs.yaml \
+```
 
 ### Required Credentials
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ or
 ```bash
 pip install syftr
 ```
-NOTE: __syftr__ works as a library, but still needs easy access to `config.yaml` and study files you intend to run. This file should be present in `/etc/syftr/config.yaml`, `~/.syftr/config.yaml`
+NOTE: __syftr__ works as a library, but still needs easy access to `config.yaml` and study files you intend to run. This file should be present in `~/.syftr/config.yaml`, or your current working directory.
 or current working directory.
 
 ### Required Credentials

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ or to use syftr as a library, install directly from PyPi:
 pip install syftr
 ```
 NOTE: __syftr__ works as a library, but still needs easy access to `config.yaml` and study files you intend to run. This file should be present in `~/.syftr/config.yaml`, or your current working directory.
+You can download sample config file to your `~/.syftr/` directory with this command
+```bash
+curl -L https://raw.githubusercontent.com/datarobot/syftr/main/config.yaml.sample \
+     -o ~/.syftr/config.yaml
+```
 
 ### Required Credentials
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ curl -L https://raw.githubusercontent.com/datarobot/syftr/main/config.yaml.sampl
 ```
 You also need studies to run __syftr__. You can write your own or download our example study with this command to current working directory
 ```bash
-curl -L https://raw.githubusercontent.com/datarobot/syftr/main/studies/example-dr-docs.yaml \
+curl -L https://raw.githubusercontent.com/datarobot/syftr/main/studies/example-dr-docs.yaml > example-dr-docs.yaml
 ```
 
 ### Required Credentials

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ or to use syftr as a library, install directly from PyPi:
 ```bash
 pip install syftr
 ```
-NOTE: __syftr__ works as a library, but still needs easy access to `config.yaml` and study files you intend to run. This file should be present in `~/.syftr/config.yaml`, or your current working directory.
-You can download sample config file to your `~/.syftr/` directory with this command
+NOTE: __syftr__ works as a library, but still needs easy access to `config.yaml` and study files you intend to run. Config file should be present as `~/.syftr/config.yaml`, or in your current working directory.
+You can download sample config file to your `~/.syftr` directory with this command
 ```bash
 curl -L https://raw.githubusercontent.com/datarobot/syftr/main/config.yaml.sample \
      -o ~/.syftr/config.yaml


### PR DESCRIPTION
syftr is available as a library and this PR adds a section on how to install it from there.