### PR TITLE
More testing required before using optuna 4.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "opentelemetry-exporter-otlp",
     "opentelemetry-sdk",
     "optimum[exporters]>=1.24.0",
-    "optuna",
+    "optuna==4.2.1",
     "overrides",
     "pals",
     "pandas",


### PR DESCRIPTION
Experiments fail when using the latest optuna version. Let's fix optuna to a version that we tested well and have a separate issue for the optuna upgrade.