### PR TITLE
[YOLO][syftr] Tweaks to what appears in pypi for OSS syftr package

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,23 +57,23 @@ __syftr__'s examples require the following credentials:
 * Azure OpenAI endpoint URL (`api_url`)
 * PostgreSQL server dsn (if no dsn is provided, will use local SQLite)
 
-To enter these credentials, copy [config.yaml.sample](config.yaml.sample) to `config.yaml` and edit the required portions.
+To enter these credentials, copy [config.yaml.sample](https://github.com/datarobot/syftr/blob/main/config.yaml.sample) to `config.yaml` and edit the required portions.
 
 ## Additional Configuration Options
 
 __syftr__ uses many components including Ray for job scheduling and PostgreSQL for storing results. In this section we describe how to configure them to run __syftr__ successfully.
 
-* The main config file of __syftr__ is `config.yaml`. You can specify paths, logging, database and Ray parameters and many others. For detailed instructions and examples, please refer to [config.yaml.sample](config.yaml.sample).
+* The main config file of __syftr__ is `config.yaml`. You can specify paths, logging, database and Ray parameters and many others. For detailed instructions and examples, please refer to [config.yaml.sample](https://github.com/datarobot/syftr/blob/main/config.yaml.sample).
 You can rename this file to `config.yaml` and fill in all necessary details according to your infrastructure.
 * You can also configure __syftr__ with environment variables: `export SYFTR_PATHS__ROOT_DIR=/foo/bar`
-* When the configuration is correct, you should be able to run [`examples/1-welcome.ipynb`](examples/1-welcome.ipynb) without any problems.
+* When the configuration is correct, you should be able to run [`examples/1-welcome.ipynb`](https://github.com/datarobot/syftr/blob/main/examples/1-welcome.ipynb) without any problems.
 * __syftr__ uses SQLite by default for Optuna storage. The `database.dsn` configuration field can be used to configure any Optuna-supported relational database storage. We recommend Postgres for distributed workloads.
 
 ## Quickstart
 
 First, run `syftr check` to validate your credentials and configuration.
 Note that most LLM connections are likely to fail if you have not provided configuration for them.
-Next, try the example Jupyter notebooks located in the [`examples`](/examples) directory.
+Next, try the example Jupyter notebooks located in the [`examples`](https://github.com/datarobot/syftr/blob/main/examples) directory.
 Or directly run a __syftr__ study using the CLI `syftr run studies/example-dr-docs.yaml --follow` or with the API:
 
 ```python
@@ -155,7 +155,7 @@ All LLM configurations defined under `generative_models:` share a common set of 
     * `system_role`: (String, Optional) The expected role name for system prompts (e.g., `SYSTEM`, `USER`). Defaults to `SYSTEM`.
 * **`temperature`**: (Float, Optional) The sampling temperature for generation. Defaults to `0.0`.
 
-See [LLM provider-specific configuration](docs/llm-providers.md) to configure each supported provider.
+See [LLM provider-specific configuration](https://github.com/datarobot/syftr/blob/main/docs/llm-providers.md) to configure each supported provider.
 
 
 ### Embedding models
@@ -182,7 +182,7 @@ Models added in the ``config.yaml`` will be automatically added to the default s
 
 ## Custom Datasets
 
-See detailed instructions [here](docs/datasets.md).
+See detailed instructions [here](https://github.com/datarobot/syftr/blob/main/docs/datasets.md).
 
 ## Citation
 
@@ -199,6 +199,6 @@ If you use this code in your research please cite the following [publication](ht
 
 ## Contributing
 
-Please read our [contributing guide](/CONTRIBUTING) for details on how to contribute to the project. We welcome contributions in the form of bug reports, feature requests, and pull requests.
+Please read our [contributing guide](https://github.com/datarobot/syftr/blob/main/CONTRIBUTING) for details on how to contribute to the project. We welcome contributions in the form of bug reports, feature requests, and pull requests.
 
-Please note we have a [code of conduct](/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](https://github.com/datarobot/syftr/blob/main/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ dependencies = [
     "vertexai==1.68.0",
 ]
 
+[project.urls]
+"Homepage" = "https://datarobot.com"
+"Source" = "https://github.com/datarobot/syftr"
+"Issues" = "https://github.com/datarobot/syftr/issues"
+
 [project.scripts]
 syftr = "syftr.cli:main"
 


### PR DESCRIPTION
# Rationale

I noticed a couple things while investigating this [package on pypi](https://pypi.org/project/syftr/):

1. I wanted a quick link to the source code but that was missing - so I added the appropriate values to the pyproject.toml

To note we leverage these (including other links too) in our Python Client seen here:
https://github.com/datarobot/public_api_client/blob/master/common_setup.py#L197-L200
<img width="480" alt="Screenshot 2025-06-12 at 6 15 37 PM" src="https://github.com/user-attachments/assets/9a0d03a3-9e21-490a-b719-8655140cabcd" />

2. Also the links in pypi (generated from README) are relative so clicking them in pypi leads to 404s like this one:

https://pypi.org/project/syftr/config.yaml.sample/

<img width="1177" alt="Screenshot 2025-06-12 at 6 16 38 PM" src="https://github.com/user-attachments/assets/c7cc9ba6-f592-41be-8f87-a2193f9f4df8" />

## Updates

- I added project URLs (more could be added as appropriate)
- I made links to files in repo. use the full URL instead of relative paths