### PR TITLE
[CFX-3026] Update ruff step in lint action to use ruff version from lock file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,24 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3  # Runs ruff check
-      - run: ruff format --check
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ">=0.4.24"
+          enable-cache: true
+          cache-local-path: /home/runner/work/_temp/setup-uv-cache
+
+      - name: Install project
+        run: uv sync --frozen --extra dev
+        env:
+          UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+
+      # Run ruff check here
+      - name: Run mypy
+        run: uv run ruff format --check
   mypy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Rationale

We want our lint github action to respect the values in our uv.lock

<hr>

I noticed that since a new version of ruff came out today there were now violation failures on the main branch

We (in my opinion) should have the ruff version used to check PRs the same as the version in the uv.lock

## Screenshots/Errors

Here's a failure:
https://github.com/datarobot/syftr/actions/runs/15744918698/job/44379005596?pr=147

<img width="1410" alt="Screenshot 2025-06-18 at 6 58 06 PM" src="https://github.com/user-attachments/assets/bc0d0953-70e7-4150-ba2a-589802d7c82b" />

