### PR TITLE
Investigate run issues

### DIFF
--- a/syftr/cli.py
+++ b/syftr/cli.py
@@ -51,7 +51,7 @@ def check():
 )
 @click.option(
     "--follow/--no-follow",
-    default=False,
+    default=True,
     help="Stream logs until the study completes.",
 )
 def run(config_path: str, follow: bool):

--- a/syftr/scripts/system_check.py
+++ b/syftr/scripts/system_check.py
@@ -498,9 +498,7 @@ You can run this script again to check your progress after addressing the issues
         )
         console.print("You can edit it and then run it from your project root with:")
         console.print()
-        console.print(
-            f"[yellow]syftr run {paths[0]} --follow[/yellow]"
-        )
+        console.print(f"[yellow]syftr run {paths[0]}[/yellow]")
         console.print()
         console.print("The configuration as is would (re)create a study with name:")
         console.print()

--- a/syftr/scripts/system_check.py
+++ b/syftr/scripts/system_check.py
@@ -499,7 +499,7 @@ You can run this script again to check your progress after addressing the issues
         console.print("You can edit it and then run it from your project root with:")
         console.print()
         console.print(
-            f"[yellow]python -m syftr.ray.submit --study-config {paths[0]}[/yellow]"
+            f"[yellow]syftr run {paths[0]} --follow[/yellow]"
         )
         console.print()
         console.print("The configuration as is would (re)create a study with name:")


### PR DESCRIPTION
I looked into the issue of the study terminating when submitted, and came to the following conclusions: When using the local ray and sqlite database the following behavior was observed on both python 3.11 and 3.12:

- `syftr run studies/matthew.hausknecht--example1--small-study--drdocs_hf.yaml` - ray job is created and automatically terminated.
- `syftr run studies/matthew.hausknecht--example1--small-study--drdocs_hf.yaml --follow` - ray job is created and runs. Output is shown to console. However, if CTRL-C is pressed, the underlying ray job terminates as well.
- `python -m syftr.ray.submit --study-config studies/matthew.hausknecht--example1--small-study--drdocs_hf.yaml` - behavior is the same as with `syftr run studies/matthew.hausknecht--example1--small-study--drdocs_hf.yaml --follow` - e.g. the ray job runs until CTRL-C is pressed.

Since the behavior is equivalent, I'd suggest using the syftr CLI, but it would be good to look into why the job behavior is different between this local mode and when submitting to a remote ray cluster.
