### PR TITLE
Using ROOT and config.yaml to identify the path to the runtime secrets

### DIFF
--- a/syftr/configuration.py
+++ b/syftr/configuration.py
@@ -138,6 +138,9 @@ class Paths(BaseModel):
     lock_dir: Annotated[Path, Field(validate_default=True)] = tmp_dir / "syftr-locks"
     nltk_dir: Annotated[Path, Field(validate_default=True)] = tmp_dir / "nltk-data"
     sqlite_dir: Annotated[Path, Field(validate_default=True)] = Path.home() / ".syftr"
+    secrets_dir: Annotated[Path, Field(validate_default=True)] = (
+        REPO_ROOT / "runtime-secrets"
+    )
 
     @property
     def templates_without_context(self) -> Path:
@@ -708,7 +711,7 @@ class Settings(BaseSettings):
             "config.yaml",
             Path(os.environ.get(SYFTR_CONFIG_FILE_ENV_NAME, "")),
         ],
-        secrets_dir="runtime-secrets",
+        secrets_dir=paths.secrets_dir,
         env_file=".env",
         env_prefix="SYFTR_",
         env_nested_delimiter="__",


### PR DESCRIPTION
The default runtime secrets folder is now correctly identified from notebooks. In addition to that, users can specify an alternative location of the secrets using the `config.yaml`. This is not mentioned in the `README.md` yet as we advice users to use the `api_key` field.
```
paths:
  secrets_dir: /home/stefan/workspace/syftr/runtime-secrets2
```